### PR TITLE
Speed up wavefunction coefficient generation

### DIFF
--- a/qiskit_addon_dice_solver/dice_solver.py
+++ b/qiskit_addon_dice_solver/dice_solver.py
@@ -370,12 +370,16 @@ def _construct_ci_vec_from_addresses_amplitudes(
     num_dets = len(uniques)
     ci_vec = np.zeros((num_dets, num_dets))
 
+    addr_map = {}
+    for i, uni_addr = enumerate(uniques):
+        addr_map[uni_addr] = i
+
     for idx, address in enumerate(addresses):
         address_a = address[0]
         address_b = address[1]
 
-        i = np.where(uniques == address_a)[0][0]
-        j = np.where(uniques == address_b)[0][0]
+        i = addr_map[address_a]
+        j = addr_map[address_b]
         ci_vec[i, j] = amps[idx]
 
     return ci_vec

--- a/qiskit_addon_dice_solver/dice_solver.py
+++ b/qiskit_addon_dice_solver/dice_solver.py
@@ -370,9 +370,7 @@ def _construct_ci_vec_from_addresses_amplitudes(
     num_dets = len(uniques)
     ci_vec = np.zeros((num_dets, num_dets))
 
-    addr_map = {}
-    for i, uni_addr in enumerate(uniques):
-        addr_map[uni_addr] = i
+    addr_map = {uni_addr: i for i, uni_addr in enumerate(uniques)}
 
     for idx, address in enumerate(addresses):
         address_a = address[0]

--- a/qiskit_addon_dice_solver/dice_solver.py
+++ b/qiskit_addon_dice_solver/dice_solver.py
@@ -371,7 +371,7 @@ def _construct_ci_vec_from_addresses_amplitudes(
     ci_vec = np.zeros((num_dets, num_dets))
 
     addr_map = {}
-    for i, uni_addr = enumerate(uniques):
+    for i, uni_addr in enumerate(uniques):
         addr_map[uni_addr] = i
 
     for idx, address in enumerate(addresses):


### PR DESCRIPTION
Create an index map for quick access during WF coeff generation. Reduces time complexity of the generation function from ``O(M*N)`` to ``O(NlogN)``, where ``M`` is the number of input determinants and ``N`` is the number of unique input determinants.

The old ``MlogN`` scaling came from the fact that we conducted a search (`np.where`) through all unique determinants (``N``) for each input determinant (``M``).

While the process of creating the coefficient array itself has been improved to ``O(M)``, the function is now bounded by the `np.unique` call, which performs an ``NlogN`` sorting routine.