### PR TITLE
Ensure a DiceExceptionError is raised when Dice fails

### DIFF
--- a/qiskit_addon_dice_solver/dice_solver.py
+++ b/qiskit_addon_dice_solver/dice_solver.py
@@ -33,18 +33,15 @@ os.environ["LD_LIBRARY_PATH"] = f"{DICE_BIN}:{os.environ.get('LD_LIBRARY_PATH', 
 class DiceExecutionError(Exception):
     """Custom exception for Dice command line application execution errors."""
 
-    def __init__(self, command, returncode, output, stderr, working_dir):
+    def __init__(self, command, returncode, log_path):
         """Initialize a ``DiceExecutionError`` instance."""
         self.command = command
         self.returncode = returncode
-        self.output = output
-        self.stderr = stderr
-        self.working_dir = working_dir
+        self.log_path = log_path
+
         message = (
             f"Command '{command}' failed with return code {returncode}\n"
-            f"Working directory: {working_dir}\n"
-            f"Output: {output}\n"
-            f"Error: {stderr}"
+            f"See the log file at {log_path} for more details."
         )
         super().__init__(message)
 
@@ -193,17 +190,17 @@ def _call_dice(working_dir: Path, mpirun_options: Sequence[str] | str | None) ->
     else:
         dice_call = ["mpirun", dice_path]
 
-    try:
-        with open(dice_log_path, "w") as logfile:
-            subprocess.run(dice_call, cwd=working_dir, stdout=logfile, stderr=logfile)
-    except subprocess.CalledProcessError as e:
+    with open(dice_log_path, "w") as logfile:
+        process = subprocess.run(
+            dice_call, cwd=working_dir, stdout=logfile, stderr=logfile
+        )
+
+    if process.returncode != 0:
         raise DiceExecutionError(
             command=dice_call,
-            returncode=e.returncode,
-            output=e.stdout,
-            stderr=e.stderr,
-            working_dir=working_dir,
-        ) from e
+            returncode=process.returncode,
+            log_path=dice_log_path,
+        )
 
 
 def _write_input_files(


### PR DESCRIPTION
The current logic only raises a ``DiceExceptionError`` when `subprocess.run` fails to execute. This isn't the right logic since `subprocess.run` will execute even if the underlying application returns a non-zero return code. This PR checks the returncode explicitly and raises a DiceExceptionError alerting users to the failure of the ``Dice`` command line application and pointing them to the logfile.