### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ### About
 
-[Qiskit addons](https://docs.quantum.ibm.com/guides/addons) are a collection of modular tools for building utility-scale workloads powered by Qiskit.
+[Qiskit addons](https://quantum.cloud.ibm.com/docs/guides/addons) are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
 This package contains a [Dice-based eigensolver [1-2]](https://sanshar.github.io/Dice/overview.html) that can be used to scale [sample-based quantum diagonalization (SQD) [3]](https://arxiv.org/abs/2405.05068) chemistry workflows past 30 orbitals. It is designed as a plugin to the [SQD Qiskit addon](https://qiskit.github.io/qiskit-addon-sqd/). No ``Dice`` executable is included in this package, but a build script is provided to assist users in properly setting up the package for installation. For an example of integrating ``qiskit-addon-dice-solver`` into SQD workflows, check out the [how-to](https://qiskit.github.io/qiskit-addon-sqd/how_tos/integrate_dice_solver.html).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,7 @@ modindex_common_prefix = ["qiskit_addon_dice_solver."]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
     "rustworkx": ("https://www.rustworkx.org/", None),
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 Qiskit addon: Dice eigensolver
 ##############################
 
-`Qiskit addons <https://docs.quantum.ibm.com/guides/addons>`_ are a collection of modular tools for building utility-scale workloads powered by Qiskit.
+`Qiskit addons <https://quantum.cloud.ibm.com/docs/guides/addons>`_ are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
 This package contains a `Dice-based eigensolver [1-2] <https://sanshar.github.io/Dice/overview.html>`_ that can be used to scale sample-based quantum diagonalization (SQD) [3] chemistry workflows past 30 orbitals. It is designed as a plugin to the `SQD Qiskit addon <https://qiskit.github.io/qiskit-addon-sqd/>`_. No ``Dice`` executable is included in this package, but a build script is provided to assist users in properly setting up the package for installation. For an example of integrating ``qiskit-addon-dice-solver`` into SQD workflows, check out the `how-to <https://qiskit.github.io/qiskit-addon-sqd/how_tos/integrate_dice_solver.html>`_.
 


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.