### PR TITLE
Faster CI strs from occupancies

### DIFF
--- a/qiskit_addon_dice_solver/dice_solver.py
+++ b/qiskit_addon_dice_solver/dice_solver.py
@@ -589,16 +589,27 @@ def _bitstring_from_occupancy_str(occupancy_str: str) -> np.ndarray:
 
 def _ci_strs_from_occupancies(occupancy_strs: list[str]) -> list[list[int]]:
     """Convert occupancies to CI strings."""
-    norb = len(occupancy_strs[0])
     ci_strs = []
     for occ in occupancy_strs:
-        bitstring = _bitstring_from_occupancy_str(occ)
-        bitstring_a = bitstring[:norb]
-        bitstring_b = bitstring[norb:]
-        ci_str_a = sum(b << i for i, b in enumerate(bitstring_a))
-        ci_str_b = sum(b << i for i, b in enumerate(bitstring_b))
-        ci_str = [ci_str_a, ci_str_b]
-        ci_strs.append(ci_str)
+        ci_str_a = 0
+        ci_str_b = 0
+        for idx, char in enumerate(occ):
+            if char == "2":
+                ci_str_a += 1 << idx
+                ci_str_b += 1 << idx
+            elif char == "a":
+                ci_str_a += 1 << idx
+            elif char == "b":
+                ci_str_b += 1 << idx
+            elif char == "0":
+                pass
+            else:
+                raise ValueError(
+                    f"Invalid character '{char}' in occupancy string. "
+                    f"Only valid characters are '2', 'a', 'b', and '0'."
+                )
+
+        ci_strs.append([ci_str_a, ci_str_b])
 
     return ci_strs
 


### PR DESCRIPTION
Currently, while converting occupancy strs to CI strs ([_ci_strs_from_occupancies](https://github.com/Qiskit/qiskit-addon-dice-solver/blob/785f8b41d882e5edd9816669a7449102061f36a9/qiskit_addon_dice_solver/dice_solver.py#L590)), the flow goes through an intermediate step ([_bitstring_from_occupancy_str](https://github.com/Qiskit/qiskit-addon-dice-solver/blob/785f8b41d882e5edd9816669a7449102061f36a9/qiskit_addon_dice_solver/dice_solver.py#L574C5-L574C34)) where occupancy strs are first converted to bitstrings, and then, bitstrings are converted into CI strs (two integers representing alpha and beta halves).

We can skip the intermediate call to [_bitstring_from_occupancy_str](https://github.com/Qiskit/qiskit-addon-dice-solver/blob/785f8b41d882e5edd9816669a7449102061f36a9/qiskit_addon_dice_solver/dice_solver.py#L574C5-L574C34) and directly convert the occupancy strs (which consists of characters `'2', 'a', 'b', and '0'`) to integer alpha and beta CI strs.

It speeds up the process significantly. 